### PR TITLE
support some environment variables of ElasticAPM

### DIFF
--- a/files/etc/rc.d/init.d/unicorn
+++ b/files/etc/rc.d/init.d/unicorn
@@ -24,10 +24,22 @@ if [ ! -f "$UNICORN_RB" ]; then
     UNICORN_RB="${APP_ROOT}/current/config/unicorn.rb"
 fi
 
+# elastic apm
+ELASTIC_ENVS=""
+if [ -n "${ELASTIC_APM_SERVICE_NAME}" ]; then
+  ELASTIC_ENVS="${ELASTIC_ENVS} ELASTIC_APM_SERVICE_NAME=${ELASTIC_APM_SERVICE_NAME}"
+fi
+if [ -n "${ELASTIC_APM_SERVER_URL}" ]; then
+  ELASTIC_ENVS="${ELASTIC_ENVS} ELASTIC_APM_SERVER_URL=${ELASTIC_APM_SERVER_URL}"
+fi
+if [ -n "${ELASTIC_APM_SECRET_TOKEN}" ]; then
+  ELASTIC_ENVS="${ELASTIC_ENVS} ELASTIC_APM_SECRET_TOKEN=${ELASTIC_APM_SECRET_TOKEN}"
+fi
+
 if [ -n "$RUBY_PATH" ]; then
-    CMD="cd $APP_ROOT/current; PATH=${RUBY_PATH}:\$PATH bundle exec unicorn -E $ENVIRONMENT -D -c $UNICORN_RB"
+    CMD="cd $APP_ROOT/current; ${ELASTIC_ENVS} PATH=${RUBY_PATH}:\$PATH bundle exec unicorn -E $ENVIRONMENT -D -c $UNICORN_RB"
 else
-    CMD="cd $APP_ROOT/current; bundle exec unicorn -E $ENVIRONMENT -D -c $UNICORN_RB"
+    CMD="cd $APP_ROOT/current; ${ELASTIC_ENVS} bundle exec unicorn -E $ENVIRONMENT -D -c $UNICORN_RB"
 fi
 
 # signal utils


### PR DESCRIPTION
ref:https://www.elastic.co/guide/en/apm/agent/ruby/current/configuration.html#config-server-url

I'll fix to support these environment variables.
```
ELASTIC_APM_SERVICE_NAME
ELASTIC_APM_SERVER_URL
ELASTIC_APM_SECRET_TOKEN
```