### PR TITLE
Add dependencies to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,7 @@
   "license": "Apache 2.0",
   "source": "git@github.com:hfm/puppet-unicorn_sysvinit.git",
   "project_page": "https://github.com/hfm/puppet-unicorn_sysvinit",
+  "dependencies": [],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",


### PR DESCRIPTION
to fix this error.
```
Error: No dependencies module metadata provided for unicorn_sysvinit
```